### PR TITLE
ELEC-154: Pin chef-solo version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
+gem 'berkshelf', '~> 5.2.0'
+gem 'foodcritic', '~> 11.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
+    backports (3.8.0)
     berkshelf (5.2.0)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (>= 2.0.2, < 4.0)
@@ -41,14 +42,27 @@ GEM
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
     cleanroom (1.0.0)
+    cucumber-core (2.0.0)
+      backports (~> 3.6)
+      gherkin (~> 4.0)
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    foodcritic (11.0.0)
+      cucumber-core (>= 1.3)
+      erubis
+      nokogiri (>= 1.5, < 2.0)
+      rake
+      rufus-lru (~> 1.0)
+      treetop (~> 1.4)
+      yajl-ruby (~> 1.1)
     fuzzyurl (0.9.0)
+    gherkin (4.1.3)
     hashie (3.4.6)
     hitimes (1.2.4)
     httpclient (2.8.3)
     json (2.0.3)
+    mini_portile2 (2.1.0)
     minitar (0.5.4)
     mixlib-archive (0.2.0)
       mixlib-log
@@ -60,8 +74,12 @@ GEM
     molinillo (0.5.5)
     multipart-post (2.0.0)
     nio4r (2.0.0)
+    nokogiri (1.7.2)
+      mini_portile2 (~> 2.1.0)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
+    polyglot (0.3.5)
+    rake (12.0.0)
     retryable (2.0.4)
     ridley (5.1.0)
       addressable
@@ -81,6 +99,7 @@ GEM
       retryable (~> 2.0)
       semverse (~> 2.0)
       varia_model (~> 0.6)
+    rufus-lru (1.1.0)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -91,15 +110,19 @@ GEM
     thor (0.19.4)
     timers (4.0.4)
       hitimes
+    treetop (1.6.8)
+      polyglot (~> 0.3)
     varia_model (0.6.0)
       buff-extensions (~> 2.0)
       hashie (>= 2.0.2, < 4.0.0)
+    yajl-ruby (1.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  berkshelf
+  berkshelf (~> 5.2.0)
+  foodcritic (~> 11.0.0)
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/vagrant-base.json
+++ b/vagrant-base.json
@@ -97,7 +97,8 @@
     }, {
       "cookbook_paths": ["chef/cookbooks", "chef/uwmidsun-cookbooks"],
       "run_list": ["git", "tmux", "vim", "stm32-dev"],
-      "type": "chef-solo"
+      "type": "chef-solo",
+      "version": "13.2.20"
     }
   ],
   "variables": {


### PR DESCRIPTION
Changes have been merged upstream, allowing ``packer`` to take a ``version`` configuration option for the ``chef-solo`` provisioner.

I've just chosen the latest version of ``chef-solo`` at the moment (``13.2.20``).