### PR TITLE
ELEC-246: Add packages

### DIFF
--- a/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
@@ -44,3 +44,5 @@ bash 'install_ruby' do
     rvm install ruby-2.3.3
   EOH
 end
+
+package 'minicom'

--- a/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
@@ -46,3 +46,7 @@ bash 'install_ruby' do
 end
 
 package 'minicom'
+
+# clang
+package 'clang'
+package 'clang-format'


### PR DESCRIPTION
Add the following packages from the source PPAs:

* minicom
* clang
* clang-format

If we want a newer version, we can probably pull the latest from LLVM or the Rust PPA.

I figured I might as well get this in first, and then do the udev rule as a separate PR once that gets tested.