### PR TITLE
ELEC-246: Add golang packages

### DIFF
--- a/chef/Berksfile
+++ b/chef/Berksfile
@@ -2,5 +2,6 @@ source 'https://supermarket.chef.io'
 
 cookbook 'apt', '~> 6.1.0'
 cookbook 'git', '~> 6.0.0'
+cookbook 'golang', '~> 1.7.0'
 cookbook 'tmux', '~> 1.5.0'
 cookbook 'vim', '~> 2.0.2'

--- a/chef/Berksfile.lock
+++ b/chef/Berksfile.lock
@@ -1,6 +1,7 @@
 DEPENDENCIES
   apt (~> 6.1.0)
   git (~> 6.0.0)
+  golang (~> 1.7.0)
   tmux (~> 1.5.0)
   vim (~> 2.0.2)
 
@@ -15,6 +16,7 @@ GRAPH
     build-essential (>= 0.0.0)
     dmg (>= 0.0.0)
     yum-epel (>= 0.0.0)
+  golang (1.7.0)
   mingw (2.0.1)
     seven_zip (>= 0.0.0)
   ohai (5.1.0)

--- a/chef/cookbooks/golang/.gitignore
+++ b/chef/cookbooks/golang/.gitignore
@@ -1,0 +1,8 @@
+/metadata.json
+/~
+
+.kitchen/
+.kitchen.local.yml
+
+Gemfile.lock
+Berksfile.lock

--- a/chef/cookbooks/golang/.kitchen.yml
+++ b/chef/cookbooks/golang/.kitchen.yml
@@ -1,0 +1,31 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: true
+
+platforms:
+- name: ubuntu-14.10
+- name: centos-6.5
+
+suites:
+- name: default
+  run_list:
+    - recipe[golang_test::default]
+    - recipe[minitest-handler]
+  attributes:
+    go:
+      owner: 'vagrant'
+      group: 'vagrant'
+- name: src
+  run_list:
+    - recipe[golang_test::default]
+    - recipe[minitest-handler]
+  attributes:
+    go:
+      from_source: true
+      arch: 'amd64'
+      owner: 'vagrant'
+      group: 'vagrant'

--- a/chef/cookbooks/golang/.travis.yml
+++ b/chef/cookbooks/golang/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+gemfile:
+   - test/support/Gemfile
+rvm:
+  - 2.0
+  - 2.1
+  - 2.2
+script: bundle exec rake foodcritic

--- a/chef/cookbooks/golang/Berksfile
+++ b/chef/cookbooks/golang/Berksfile
@@ -1,0 +1,8 @@
+source "https://supermarket.getchef.com"
+
+metadata
+
+group :integration do
+  cookbook "minitest-handler"
+  cookbook 'golang_test', path: 'test/cookbooks/golang_test'
+end

--- a/chef/cookbooks/golang/CHANGELOG.md
+++ b/chef/cookbooks/golang/CHANGELOG.md
@@ -1,0 +1,31 @@
+# CHANGELOG for golang
+
+This file is used to list changes made in each version of golang.
+
+## 1.4.0:
+
+* Add build action to LWRP
+* Update default go version to 1.2.2
+* Add autodetection the platform architecture
+* Change package location to http://golang.org/dl/
+
+## 1.3.0:
+
+## 1.2.0:
+
+## 1.1.0:
+
+* Added package LWRP
+* Configurable `gopath` & `gobin`
+
+## 1.0.2:
+
+* Lets users easily specify another install dir
+
+## 1.0.1:
+
+* Avoid extra unpacked copy of Go
+
+## 1.0.0:
+
+* Initial release of golang

--- a/chef/cookbooks/golang/Gemfile
+++ b/chef/cookbooks/golang/Gemfile
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'foodcritic', '~> 5.0'
+
+group :integration do
+  gem 'berkshelf', '~> 3.2.0'
+  gem 'test-kitchen', '~> 1.4.0'
+  gem 'kitchen-vagrant', '~> 0.18.0'
+end
+

--- a/chef/cookbooks/golang/LICENSE
+++ b/chef/cookbooks/golang/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/chef/cookbooks/golang/README.md
+++ b/chef/cookbooks/golang/README.md
@@ -1,0 +1,158 @@
+# <a name="title"></a> golang (Chef cookbook for Go)
+
+## <a name="description"></a> Description
+
+Chef cookbook for [Go programming language](http://golang.org/).
+
+## <a name="requirements"></a> Requirements
+
+### <a name="requirements-platform"></a> Platform
+
+* Ubuntu (12.04/13.04/14.10)
+* Debian (6.0)
+
+**Notes**: This cookbook has been tested on the listed platforms. It
+may work on other platforms with or without modification. Please
+[report issues](https://github.com/NOX73/chef-golang/issues) any additional platforms so they can be added.
+
+
+## <a name="usage"></a> Usage
+
+#### golang::default
+
+Just include `golang` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[golang]"
+  ]
+}
+```
+
+#### golang::packages
+
+To install Go packages using node attributes, include `golang::packages` in your node's `run_list`, and use the `['go']['packages']` attribute:
+
+```json
+{
+  "name":"my_node",
+  "go": {
+    "packages": [
+      "launchpad.net/gocheck"
+    ]
+  },
+  "run_list": [
+    "recipe[golang::packages]"
+  ]
+}
+```
+
+
+## <a name="attributes"></a> Attributes
+
+#### golang::default
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['go']['version']</tt></td>
+    <td>String</td>
+    <td>Go version</td>
+    <td><tt>1.4</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['platform']</tt></td>
+    <td>String</td>
+    <td>`amd64` or `i386`</td>
+    <td><tt>amd64</tt></td>
+  </tr>
+    <tr>
+    <td><tt>['go']['scm']</tt></td>
+    <td>Boolean</td>
+    <td>install SCM dependencies `git`, `hg`, and `bzr`</td>
+    <td><tt>true</tt></td>
+  </tr>
+  </tr>
+  <tr>
+    <td><tt>['go']['packages']</tt></td>
+    <td>Array</td>
+    <td>Go packages to install when using the `golang::packages` recipe</td>
+    <td><tt>[]</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['owner']</tt></td>
+    <td>String</td>
+    <td>The user account that owns $GOPATH</td>
+    <td><tt>root</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['group']</tt></td>
+    <td>String</td>
+    <td>The group that owns $GOPATH</td>
+    <td><tt>root</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['mode']</tt></td>
+    <td>String</td>
+    <td>The mode of $GOPATH</td>
+    <td><tt>0755</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['from_source']</tt></td>
+    <td>Boolean</td>
+    <td>Install go from source</td>
+    <td><tt>false</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['os']</tt></td>
+    <td>String</td>
+    <td>Build go for which operating system</td>
+    <td><tt>linux</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['arch']</tt></td>
+    <td>String</td>
+    <td>Build go for which architecture</td>
+    <td><tt>arm</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['arm']</tt></td>
+    <td>String</td>
+    <td>Build go for which arm version</td>
+    <td><tt>6</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['go']['source_method']</tt></td>
+    <td>String</td>
+    <td>Choose which install script should be used</td>
+    <td><tt>all.bash</tt></td>
+  </tr>
+</table>
+
+## <a name="testing"></a> Testing
+
+This project have [foodcritic](https://github.com/acrmp/foodcritic) for syntax checking and
+[test-kitchen](https://github.com/opscode/test-kitchen) for integration testing. You can run the test suite by
+typing: `rake kitchen:all` (may be slow for the first time).
+
+In order to run these tests, the following
+[requirements](https://github.com/opscode/kitchen-vagrant#-requirements) must be
+satisfied:
+
+* [Vagrant](http://vagrantup.com/) (>= 1.1.0)
+* [VirtualBox](https://www.virtualbox.org/)
+* [Vagrant Berkshelf Plugin](http://rubygems.org/gems/vagrant-berkshelf)
+
+## <a name="contributing"></a> Contributing
+
+1. Fork the repository
+2. Create a named feature branch (like `add_component_x`)
+3. Write you change
+4. Test it by running `rake kitchen:all`
+5. Submit a Pull Request

--- a/chef/cookbooks/golang/Rakefile
+++ b/chef/cookbooks/golang/Rakefile
@@ -1,0 +1,18 @@
+#!/usr/bin/env rake
+
+require 'foodcritic'
+require 'rake/testtask'
+
+# FC043 is excluded because of the problem described in https://github.com/NOX73/chef-golang/issues/3
+FoodCritic::Rake::LintTask.new do |t|
+  t.options = { :fail_tags => ['any'], :tags => ['~FC043'] }
+end
+
+begin
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+rescue LoadError
+  puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV['CI']
+end
+
+task :default => :foodcritic

--- a/chef/cookbooks/golang/attributes/default.rb
+++ b/chef/cookbooks/golang/attributes/default.rb
@@ -1,0 +1,20 @@
+default['go']['version'] = '1.5'
+default['go']['platform'] = node['kernel']['machine'] =~ /i.86/ ? '386' : 'amd64'
+default['go']['filename'] = "go#{node['go']['version']}.#{node['os']}-#{node['go']['platform']}.tar.gz"
+default['go']['from_source'] = false
+if node['go']['from_source']
+  default['go']['filename'] = "go#{node['go']['version']}.src.tar.gz"
+  default['go']['os'] = 'linux'
+  default['go']['arch'] = 'arm'
+  default['go']['arm'] = '6'
+  default['go']['source_method'] = "all.bash"
+end
+default['go']['url'] = "http://golang.org/dl/#{node['go']['filename']}"
+default['go']['install_dir'] = '/usr/local'
+default['go']['gopath'] = '/opt/go'
+default['go']['gobin'] = '/opt/go/bin'
+default['go']['scm'] = true
+default['go']['packages'] = []
+default['go']['owner'] = 'root'
+default['go']['group'] = 'root'
+default['go']['mode'] = 0755

--- a/chef/cookbooks/golang/libraries/matchers.rb
+++ b/chef/cookbooks/golang/libraries/matchers.rb
@@ -1,0 +1,11 @@
+if defined?(ChefSpec)
+
+  def install_golang_package(package)
+    ChefSpec::Matchers::ResourceMatcher.new(:golang_package, :install, package)
+  end
+
+  def update_golang_package(package)
+    ChefSpec::Matchers::ResourceMatcher.new(:golang_package, :update, package)
+  end
+
+end

--- a/chef/cookbooks/golang/providers/package.rb
+++ b/chef/cookbooks/golang/providers/package.rb
@@ -1,0 +1,78 @@
+action :install do
+
+  tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-')
+
+  bash "Installing package #{new_resource.name}" do
+    code "#{node['go']['install_dir']}/go/bin/go get -v #{new_resource.name} 2> >(grep -v '(download)$' > #{tmp_file_path})"
+    action :nothing
+    user node['go']['owner']
+    group node['go']['group']
+    environment({
+      'GOPATH' => node['go']['gopath'],
+      'GOBIN' => node['go']['gobin']
+    })
+  end.run_action(:run)
+
+  f = file tmp_file_path do
+    content ''
+  end
+  f.run_action(:create)
+
+  new_resource.updated_by_last_action(f.updated?)
+end
+
+action :update do
+
+  tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-')
+
+  bash "Updating package #{new_resource.name}" do
+    code "#{node['go']['install_dir']}/go/bin/go get -v -u #{new_resource.name} 2> >(grep -v '(download)$' > #{tmp_file_path})"
+    action :nothing
+    user node['go']['owner']
+    group node['go']['group']
+    environment({
+      'GOPATH' => node['go']['gopath'],
+      'GOBIN' => node['go']['gobin']
+    })
+  end.run_action(:run)
+
+  f = file tmp_file_path do
+    content ''
+  end
+  f.run_action(:create)
+
+  new_resource.updated_by_last_action(f.updated?)
+end
+
+action :build do
+
+  tmpdir = directory (::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-') + "_BUILD") do
+    action :nothing
+    owner node['go']['owner']
+    group node['go']['group']
+    recursive true
+  end
+
+  # create temporary directory to executing the build in
+  tmpdir.run_action(:create)
+
+  b = bash "Build package #{new_resource.name}" do
+    code "#{node['go']['install_dir']}/go/bin/go build #{new_resource.name}"
+    action :nothing
+    cwd tmpdir.name
+    user node['go']['owner']
+    group node['go']['group']
+    environment({
+      'GOPATH' => node['go']['gopath'],
+      'GOBIN' => node['go']['gobin']
+    })
+  end
+
+  # execute the build
+  b.run_action(:run)
+
+  # remove temporary directory
+  # tmpdir.run_action(:delete)
+
+  new_resource.updated_by_last_action(b.updated?)
+end

--- a/chef/cookbooks/golang/recipes/default.rb
+++ b/chef/cookbooks/golang/recipes/default.rb
@@ -1,0 +1,106 @@
+#
+# Cookbook Name:: golang
+# Recipe:: default
+#
+# Copyright 2013, Alexander Rozhnov
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+node.default['go']['platform'] = node['kernel']['machine'] =~ /i.86/ ? '386' : 'amd64'
+node.default['go']['filename'] = "go#{node['go']['version']}.#{node['os']}-#{node['go']['platform']}.tar.gz"
+node.default['go']['url'] = "http://golang.org/dl/#{node['go']['filename']}"
+
+bash "install-golang" do
+  cwd Chef::Config[:file_cache_path]
+  code <<-EOH
+    rm -rf go
+    rm -rf #{node['go']['install_dir']}/go
+    tar -C #{node['go']['install_dir']} -xzf #{node['go']['filename']}
+  EOH
+  not_if { node['go']['from_source'] }
+  action :nothing
+end
+
+bash "build-golang" do
+  cwd Chef::Config[:file_cache_path]
+  code <<-EOH
+    rm -rf go
+    rm -rf #{node['go']['install_dir']}/go
+    tar -C #{node['go']['install_dir']} -xzf #{node['go']['filename']}
+    cd #{node['go']['install_dir']}/go/src
+    mkdir -p $GOBIN
+    ./#{node['go']['source_method']}
+  EOH
+  environment ({
+    'GOROOT' => "#{node['go']['install_dir']}/go",
+    'GOBIN'  => '$GOROOT/bin',
+    'GOOS'   => node['go']['os'],
+    'GOARCH' => node['go']['arch'],
+    'GOARM'  => node['go']['arm']
+  })
+  only_if { node['go']['from_source'] }
+  action :nothing
+end
+
+if node['go']['from_source']
+  case node["platform"]
+  when 'debian', 'ubuntu'
+    packages = %w(build-essential)
+  when 'redhat', 'centos', 'fedora'
+    packages = %w(gcc glibc-devel)
+  end
+  packages.each do |dev_package|
+    package dev_package do
+      action :install
+    end
+  end
+end
+
+remote_file File.join(Chef::Config[:file_cache_path], node['go']['filename']) do
+  source node['go']['url']
+  owner 'root'
+  mode 0644
+  notifies :run, 'bash[install-golang]', :immediately
+  notifies :run, 'bash[build-golang]', :immediately
+  not_if "#{node['go']['install_dir']}/go/bin/go version | grep \"go#{node['go']['version']} \""
+end
+
+directory node['go']['gopath'] do
+  action :create
+  recursive true
+  owner node['go']['owner']
+  group node['go']['group']
+  mode node['go']['mode']
+end
+
+directory node['go']['gobin'] do
+  action :create
+  recursive true
+  owner node['go']['owner']
+  group node['go']['group']
+  mode node['go']['mode']
+end
+
+template "/etc/profile.d/golang.sh" do
+  source "golang.sh.erb"
+  owner 'root'
+  group 'root'
+  mode 0755
+end
+
+if node['go']['scm']
+  %w(git mercurial bzr).each do |scm|
+    package scm
+  end
+end

--- a/chef/cookbooks/golang/recipes/packages.rb
+++ b/chef/cookbooks/golang/recipes/packages.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: golang
+# Recipe:: packages
+#
+# Copyright 2013, Alexander Rozhnov
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+include_recipe 'golang'
+
+node['go']['packages'].each do |package|
+  golang_package package
+end

--- a/chef/cookbooks/golang/resources/package.rb
+++ b/chef/cookbooks/golang/resources/package.rb
@@ -1,0 +1,4 @@
+actions :install, :update, :build
+default_action :install
+
+attribute :name, :kind_of => String, :name_attribute => true

--- a/chef/cookbooks/golang/templates/default/golang.sh.erb
+++ b/chef/cookbooks/golang/templates/default/golang.sh.erb
@@ -1,0 +1,3 @@
+export PATH=$PATH:<%= node['go']['install_dir'] %>/go/bin:<%= node['go']['gobin'] %>
+export GOPATH=<%= node['go']['gopath'] %>
+export GOBIN=<%= node['go']['gobin'] %>

--- a/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
@@ -44,3 +44,25 @@ bash 'install_ruby' do
     rvm install ruby-2.3.3
   EOH
 end
+
+apt_repository 'glide' do
+  uri 'ppa:masterminds/glide'
+  distribution node['lsb']['codename']
+  components ['main']
+  keyserver 'keyserver.ubuntu.com'
+  key '890C81B2'
+  deb_src true
+  action :add
+end
+
+ruby_block "insert_line" do
+  block do
+    file = Chef::Util::FileEdit.new("/home/vagrant/.bashrc")
+    file.insert_line_if_no_match("/export GOPATH=\/home\/vagrant\/go/", "export GOPATH=/home/vagrant/go")
+    file.insert_line_if_no_match("/export GOBIN=$GOPATH\/bin/", "export GOBIN=$GOPATH/bin")
+    file.insert_line_if_no_match("/export PATH=$GOPATH\/bin:$PATH/", "export PATH=$GOPATH/bin:$PATH")
+    file.write_file
+  end
+end
+
+package 'glide'

--- a/vagrant-base.json
+++ b/vagrant-base.json
@@ -96,7 +96,14 @@
       "type": "shell"
     }, {
       "cookbook_paths": ["chef/cookbooks", "chef/uwmidsun-cookbooks"],
-      "run_list": ["git", "tmux", "vim", "stm32-dev"],
+      "json": {
+        "go": {
+          "version": "1.8.3",
+          "owner": "vagrant",
+          "group": "vagrant"
+        }
+      },
+      "run_list": ["git", "golang", "tmux", "vim", "stm32-dev"],
       "type": "chef-solo",
       "version": "13.2.20"
     }


### PR DESCRIPTION
This _should_ install golang 1.8.3 and Glide, and then properly set up the ``$PATH`` so that ``go get`` works correctly and ``$GOBIN`` is included in the path.

Changes of note:

* ``vagrant-base.json``
* ``chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb``

For testing this, cloning the telemetry project and running ``make`` should complete successfully without any errors.

Ideally I'd like to refactor a lot of the packer repo at some point so each package has its own cookbook, and then have wrapper cookbooks for application stuff, and do everything with roles (basically best practices). I'll create a ticket to track that, but it's super super low priority.