### PR TITLE
ELEC-246: Add udev rule and minicom config

### DIFF
--- a/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
@@ -44,3 +44,23 @@ bash 'install_ruby' do
     rvm install ruby-2.3.3
   EOH
 end
+
+execute 'udevadm-trigger' do
+  action :nothing
+  command '/sbin/udevadm trigger --action=add'
+end
+
+template '/etc/udev/rules.d/99-chef.rules' do
+  source 'udev.rules.erb'
+  owner 'root'
+  group 'root'
+  mode 0o644
+  notifies :run, 'execute[udevadm-trigger]'
+end
+
+template '/etc/minicom/minirc.dfl' do
+  source 'minirc.dfl.erb'
+  owner 'root'
+  group 'root'
+  mode 0o644
+end

--- a/chef/uwmidsun-cookbooks/stm32-dev/templates/default/minirc.dfl.erb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/templates/default/minirc.dfl.erb
@@ -1,0 +1,5 @@
+########################################################################
+# Minicom configuration file - use "minicom -s" to change parameters.
+
+# Add CR after each LF
+pu addcarreturn    Yes

--- a/chef/uwmidsun-cookbooks/stm32-dev/templates/default/udev.rules.erb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/templates/default/udev.rules.erb
@@ -1,0 +1,3 @@
+# DO NOT EDIT - This file is being maintained by Chef
+
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="da42", SYMLINK+="ttyCMSIS", MODE="0666"


### PR DESCRIPTION
This _should_ add a working udev rule and configure minicom correctly. This basically cherry picks the changes in the ``elec_246_udev_minicom`` related to the udev rule and the minicom config.