### PR TITLE
ELEC-330: Update to latest LTS and add missing Python tools

### DIFF
--- a/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
@@ -110,3 +110,9 @@ end
 execute 'update-alternatives clang-format-5.0' do
   command 'update-alternatives --install /usr/local/bin/clang-format clang-format `which clang-format-5.0` 10'
 end
+
+###########################
+# Python
+###########################
+package 'python3-pip'
+package 'pylint3'

--- a/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
@@ -55,7 +55,7 @@ ruby_block "insert_line" do
   end
 end
 
-package 'glide'
+package 'golang-glide'
 
 
 ###########################

--- a/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
@@ -115,4 +115,6 @@ end
 # Python
 ###########################
 package 'python3-pip'
-package 'pylint3'
+execute 'pylint' do
+  command 'pip3 install pylint'
+end

--- a/vagrant-base.json
+++ b/vagrant-base.json
@@ -120,7 +120,7 @@
     }
   ],
   "variables": {
-    "box_basename": "ubuntu-16.04",
+    "box_basename": "ubuntu-18.04",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "40960",
@@ -128,17 +128,17 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "29a8b9009509b39d542ecb229787cdf48f05e739a932289de9e9858d7c487c80",
+    "iso_checksum": "a7f5c7b0cdd0e9560d78f1e47660e066353bb8a79eb78d1fc3f4ea62a07e6cbc",
     "iso_checksum_type": "sha256",
-    "iso_name": "ubuntu-16.04.1-server-amd64.iso",
+    "iso_name": "ubuntu-18.04-server-amd64.iso",
     "memory": "1024",
     "metadata": "metadata.json",
-    "mirror": "http://old-releases.ubuntu.com/releases",
-    "mirror_directory": "16.04.1",
-    "name": "ubuntu-16.04",
+    "mirror": "http://cdimage.ubuntu.com",
+    "mirror_directory": "releases/18.04/release",
+    "name": "ubuntu-18.04",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-15.10/preseed.cfg",
-    "template": "ubuntu-16.04-amd64",
+    "template": "ubuntu-18.04-amd64",
     "version": "2.1.TIMESTAMP"
   }
 }


### PR DESCRIPTION
This bumps to Bionic (18.04 LTS) and adds the missing Python tools:

* `pip3`
* `pylint`

Figured we might as well jump on the latest instead of waiting for the 
point release, but LMK if anyone has any complaints.

Tested building the projects using:

```bash
# firmware
make build_all PLATFORM=stm32f0xx
make build_all PLATFORM=x86

# telemetry
make
```

And aside from `canD` no longer being a valid Golang package name, 
everything seems to work. Glide is actually deprecated now, so 
not sure how we want to proceed with that? Is it worth migrating to 
`dep`, or switching to something else?