### PR TITLE
ELEC-559: Add Digi XBee to udev rules

### DIFF
--- a/chef/uwmidsun-cookbooks/stm32-dev/templates/default/udev.rules.erb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/templates/default/udev.rules.erb
@@ -1,3 +1,6 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
+# CMSIS probe
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="da42", SYMLINK+="ttyCMSIS", MODE="0666"
+# Digi XBee
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", SYMLINK+="ttyXbee", MODE="0666"


### PR DESCRIPTION
Add Digi XBee to udev rules. This way you don't need to search through 
all the enumerated USB serial devices each time. This is the second 
part of the two-part change.

In order to roll this out, we'll probably need to deploy a new version 
of the box.
