### PR TITLE
ELEC-561: Add can-utils package

### DIFF
--- a/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
+++ b/chef/uwmidsun-cookbooks/stm32-dev/recipes/default.rb
@@ -2,6 +2,7 @@ Chef::Log.info('Add: Basic packages from xenial repos')
 
 [
   'build-essential',
+  'can-utils',
   'gdb',
   'openocd'
 ].each do |p|


### PR DESCRIPTION
Add `can-utils` to support SocketCAN userspace applications

Basically, it's a pain to tell people to do

```bash
sudo apt install can-utils
```

in order to use `slcand`, `candump` and `canplayer` (and the rest of the SocketCAN userspace applications), and tbh `box` should have everything packaged.